### PR TITLE
Refactor/11 validation

### DIFF
--- a/src/dot-notation.ts
+++ b/src/dot-notation.ts
@@ -77,6 +77,39 @@ export function getAll(object: ObjectType, notation: Notation): ObjectMatch[] {
 }
 
 /**
+ * Gets the next value at an index. If its undefined it will be set to a empty
+ * object then returned.
+ */
+function getNextValue(index: any, object: any): any {
+  if (typeof index === "undefined" || typeof object === "undefined") {
+    return undefined;
+  }
+
+  if (typeof object[index] === "undefined") {
+    object[index] = {};
+  }
+
+  return object[index];
+}
+
+/**
+ * Walks the notation tracking the value in the object. At the end will be to
+ * value that you can set the value at
+ */
+function walkNotation(object: ObjectType, notation: string[]): any {
+  while (notation.length > 1) {
+    const nextValue = getNextValue(notation.shift(), object);
+    if (typeof nextValue === "undefined") {
+      break;
+    }
+
+    object = nextValue;
+  }
+
+  return object;
+}
+
+/**
  * Set a value in a object from a dot notation
  */
 export function set(object: ObjectType, notation: Notation, value: any): void {
@@ -88,18 +121,7 @@ export function set(object: ObjectType, notation: Notation, value: any): void {
     notation = notation.split(".");
   }
 
-  while (notation.length > 1) {
-    const index = notation.shift();
-    if (typeof index === "undefined" || typeof object === "undefined") {
-      break;
-    }
-
-    if (typeof object[index] === "undefined") {
-      object[index] = {};
-    }
-
-    object = object[index];
-  }
+  object = walkNotation(object, notation);
 
   const index = notation.shift();
   if (typeof index === "undefined" || typeof object === "undefined") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from "./input-group";
 export * from "./list-group";
 export * from "./radio-group";
 export * from "./select-group";
+export * from "./validator";

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,0 +1,97 @@
+import { getAll } from "./dot-notation";
+
+/**
+ * Options that will be passed in that will help you get the data that will be
+ * validated.
+ */
+type ValidationOptions = {
+  /**
+   * The path that is getting validated. This is the path you have used in your
+   * rule. For example `users..name`
+   */
+  attribute: string;
+  /**
+   * The attribute string that is getting validated. This is the full string
+   * that has been resolved from the path for example `users.0.name`
+   */
+  path: string;
+  /**
+   * The individual value that is getting validated.
+   */
+  value: any;
+};
+
+/**
+ * A callback function that will validate a value. It must return a string, if
+ * the string is not empty then it will include a error message that will be
+ * displayed to the user.
+ */
+type ValidationFunction<T> = (formState: T, options: ValidationOptions) => string;
+
+/**
+ * A list of rules that will can be validated. The key is a dot notation that
+ * supports json path style deep scan for matching multiple values.
+ */
+type Rules<T> = Record<string, ValidationFunction<T>[]>;
+
+/**
+ * A list of error messages keyed by an attribute. This is the full resolved
+ * notation that is used as a input attribute.
+ */
+export type ErrorBag = Record<string, string[]>;
+
+export class Validator<T> {
+  /**
+   * This of rules that data will be validated against
+   */
+  private rules: Rules<T>;
+
+  /**
+   * Set up the validator
+   */
+  constructor(rules: Rules<T> = {}) {
+    this.rules = rules;
+  }
+
+  /**
+   * Add a new rule to the validator. If a rules already exists for the
+   * attribute then the function will be added to it.
+   */
+  addRule(attribute: string, validator: ValidationFunction<T>) {
+    if (typeof this.rules[attribute] === "undefined") {
+      this.rules[attribute] = [];
+    }
+
+    this.rules[attribute].push(validator);
+    return this;
+  }
+
+  /**
+   * Validates some data with the rules returning the errors.
+   */
+  async validate(data: T): Promise<ErrorBag> {
+    const validationErrors: ErrorBag = {};
+    for (const [attribute, validationFunctions] of Object.entries(this.rules)) {
+      getAll(data as any, attribute).forEach(({ path, value }) => {
+        const errors = validationFunctions
+          .map((validationFunction) => validationFunction(data, { attribute, path, value }))
+          .filter((item) => item);
+
+        if (errors.length > 0) {
+          validationErrors[path] = errors;
+        }
+      });
+    }
+
+    return validationErrors;
+  }
+}
+
+/**
+ * Helper function to create the validator functional style
+ */
+export function createValidator<T = any>(rules: Rules<T> = {}) {
+  return new Validator(rules);
+}
+
+export default createValidator;

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -26,7 +26,7 @@ type ValidationOptions = {
  * the string is not empty then it will include a error message that will be
  * displayed to the user.
  */
-type ValidationFunction<T> = (formState: T, options: ValidationOptions) => string;
+export type ValidationFunction<T> = (formState: T, options: ValidationOptions) => string;
 
 /**
  * A list of rules that will can be validated. The key is a dot notation that

--- a/tests/check-group.spec.tsx
+++ b/tests/check-group.spec.tsx
@@ -24,11 +24,11 @@ it("will render and submit with a checkbox attribute", async () => {
   await userEvent.click(getByText("Submit"));
 
   expect(onSubmit).toBeCalledTimes(1);
-  expect(onSubmit).toBeCalledWith({ formState: { checkMe: true } });
+  expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { checkMe: true } }));
 
   await userEvent.click(getByLabelText("Check"));
   await userEvent.click(getByText("Submit"));
 
   expect(onSubmit).toBeCalledTimes(2);
-  expect(onSubmit).toBeCalledWith({ formState: { checkMe: false } });
+  expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { checkMe: false } }));
 });

--- a/tests/dot-notaion.spec.tsx
+++ b/tests/dot-notaion.spec.tsx
@@ -1,4 +1,4 @@
-import { get, set } from "../src/dot-notation";
+import { get, getAll, set } from "../src/dot-notation";
 
 it("will get a value", () => {
   const input = { a: { b: "value" } };
@@ -37,4 +37,54 @@ it("will set empty objects", () => {
   set(input, "a.b", "new value");
 
   expect(input.a.b).toBe("new value");
+});
+
+it("will get all matching", () => {
+  const input: any = {
+    users: [{ name: "Ade" }, { name: "John" }, { name: "Jane" }],
+  };
+
+  expect(getAll(input, "users..name")).toStrictEqual([
+    { path: "users.0.name", value: "Ade" },
+    { path: "users.1.name", value: "John" },
+    { path: "users.2.name", value: "Jane" },
+  ]);
+});
+
+it("will get all matching", () => {
+  const input: any = {
+    tags: ["One", "Two", "Three"],
+  };
+
+  expect(getAll(input, "tags.")).toStrictEqual([
+    { path: "tags.0", value: "One" },
+    { path: "tags.1", value: "Two" },
+    { path: "tags.2", value: "Three" },
+  ]);
+});
+
+it("will get all nested matching", () => {
+  const input: any = {
+    users: [
+      { name: "Ade", tags: [{ content: "One" }, { content: "Two" }] },
+      { name: "John", tags: [{ content: "One" }] },
+      { name: "Jane", tags: [{ content: "One" }] },
+    ],
+  };
+
+  expect(getAll(input, "users..tags..content")).toStrictEqual([
+    { path: "users.0.tags.0.content", value: "One" },
+    { path: "users.0.tags.1.content", value: "Two" },
+    { path: "users.1.tags.0.content", value: "One" },
+    { path: "users.2.tags.0.content", value: "One" },
+  ]);
+});
+
+it("will get all with undefined", () => {
+  const input: any = { users: [{}, {}] };
+
+  expect(getAll(input, "users..firstname")).toStrictEqual([
+    { path: "users.0.firstname", value: undefined },
+    { path: "users.1.firstname", value: undefined },
+  ]);
 });

--- a/tests/input-component.tsx
+++ b/tests/input-component.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import InputGroup from "../src/input-group";
+
+export const Input = ({ attribute, type }: { attribute: string; type?: string }) => (
+  <InputGroup attribute={attribute}>
+    {({ props, error }) => (
+      <div>
+        <label htmlFor={attribute}>{attribute}</label>
+        <input {...props} type={type || "text"} />
+        <p>{error}</p>
+      </div>
+    )}
+  </InputGroup>
+);
+
+export default Input;

--- a/tests/list-group.spec.tsx
+++ b/tests/list-group.spec.tsx
@@ -40,18 +40,18 @@ it("will render and submit with a radio list", async () => {
   await userEvent.click(getByText("Submit"));
 
   expect(onSubmit).toBeCalledTimes(1);
-  expect(onSubmit).toBeCalledWith({ formState: { tags: [""] } });
+  expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { tags: [""] } }));
 
   await userEvent.type(getByLabelText("Tag 1"), "Tag One");
   await userEvent.click(getByText("Submit"));
 
   expect(onSubmit).toBeCalledTimes(2);
-  expect(onSubmit).toBeCalledWith({ formState: { tags: ["Tag One"] } });
+  expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { tags: ["Tag One"] } }));
 
   await userEvent.click(getByText("Add Tag"));
   await userEvent.type(getByLabelText("Tag 2"), "Tag Two");
   await userEvent.click(getByText("Submit"));
 
   expect(onSubmit).toBeCalledTimes(3);
-  expect(onSubmit).toBeCalledWith({ formState: { tags: ["Tag One", "Tag Two"] } });
+  expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { tags: ["Tag One", "Tag Two"] } }));
 });

--- a/tests/radio-group.spec.tsx
+++ b/tests/radio-group.spec.tsx
@@ -35,11 +35,11 @@ it("will render and submit with a radio list", async () => {
   await userEvent.click(getByText("Submit"));
 
   expect(onSubmit).toBeCalledTimes(1);
-  expect(onSubmit).toBeCalledWith({ formState: { pickOne: "one" } });
+  expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { pickOne: "one" } }));
 
   await userEvent.click(getByLabelText("Two"));
   await userEvent.click(getByText("Submit"));
 
   expect(onSubmit).toBeCalledTimes(2);
-  expect(onSubmit).toBeCalledWith({ formState: { pickOne: "two" } });
+  expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { pickOne: "two" } }));
 });

--- a/tests/select-group.spec.tsx
+++ b/tests/select-group.spec.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Form from "../src/form";
 import SelectGroup from "../src/select-group";
@@ -50,7 +50,7 @@ it("will render and submit stuff", async () => {
   fireEvent.change(getByLabelText("Select"), { target: { value: "two" } });
   fireEvent.click(getByText("Submit"));
 
-  expect(onSubmit).toBeCalledTimes(1);
+  await waitFor(() => expect(onSubmit).toBeCalledTimes(1));
   expect(onSubmit).toBeCalledWith(
     expect.objectContaining({
       formState: expect.objectContaining({ selectMe: "two" }),
@@ -70,7 +70,7 @@ it("will render and submit multiple values", async () => {
   userEvent.selectOptions(getByLabelText("Select"), ["three"]);
   fireEvent.click(getByText("Submit"));
 
-  expect(onSubmit).toBeCalledTimes(1);
+  await waitFor(() => expect(onSubmit).toBeCalledTimes(1));
   expect(onSubmit).toBeCalledWith(
     expect.objectContaining({
       formState: expect.objectContaining({ selectMe: ["three"] }),

--- a/tests/validation.spec.tsx
+++ b/tests/validation.spec.tsx
@@ -46,6 +46,28 @@ it("will validate the data with a raw function", async () => {
   await waitFor(() => expect(screen.getByText("First name is required")).not.toBeNull());
 });
 
+it("will validate after input delay", async () => {
+  const validate = jest.fn();
+  const validateAttribute = jest.fn(async () => []);
+
+  render(
+    <Form
+      initialValues={{ firstName: "" }}
+      onSubmit={({ formState }) => formState}
+      validator={{ validate, validateAttribute }}
+    >
+      <Input attribute="firstName" />
+      <button>submit</button>
+    </Form>
+  );
+
+  await userEvent.type(screen.getByLabelText("firstName"), "testing");
+  await waitFor(() => expect(validateAttribute).toHaveBeenCalledTimes(1));
+
+  await userEvent.click(screen.getByText("submit"));
+  await waitFor(() => expect(validate).toHaveBeenCalledTimes(1));
+});
+
 it("will validate nested data", async () => {
   const validator = createValidator().addRule("user.firstname", required("user.firstname"));
 

--- a/tests/validation.spec.tsx
+++ b/tests/validation.spec.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import Form from "../src/form";
+import Input from "./input-component";
+
+import createValidator from "../src/validator";
+import { get } from "../src/dot-notation";
+
+afterEach(cleanup);
+
+const required = (attribute: string) => (formState: any) => {
+  if (!get(formState, attribute)) {
+    return "Required";
+  }
+
+  return "";
+};
+
+type User = {
+  firstName: string;
+};
+
+const validator = createValidator<User>({
+  firstName: [
+    ({ firstName }) => {
+      if (!firstName || firstName.length === 0) {
+        return "First name is required";
+      }
+
+      return "";
+    },
+  ],
+});
+
+it("will validate the data with a raw function", async () => {
+  render(
+    <Form initialValues={{ firstName: "" }} onSubmit={({ formState }) => formState} validator={validator}>
+      <Input attribute="firstName" />
+      <button>submit</button>
+    </Form>
+  );
+
+  await userEvent.click(screen.getByText("submit"));
+  await waitFor(() => expect(screen.getByText("First name is required")).not.toBeNull());
+});
+
+it("will validate nested data", async () => {
+  const validator = createValidator().addRule("user.firstname", required("user.firstname"));
+
+  let result = await validator.validate({});
+  expect(result).toStrictEqual({ "user.firstname": ["Required"] });
+
+  result = await validator.validate({ user: { firstname: "Testing" } });
+  expect(result).toStrictEqual({});
+});
+
+it("will validate array data", async () => {
+  const validator = createValidator().addRule("users..firstname", required("users..firstname"));
+
+  const result = await validator.validate({ users: [{}, {}] });
+  expect(result).toStrictEqual({ "users.0.firstname": ["Required"], "users.1.firstname": ["Required"] });
+});


### PR DESCRIPTION
First look at refactoring the validation. This now supports JSON path style deep scanning. 

```js
const validator = createValidator().addRule("users..firstname", requiredValidationFunction);
const result = await validator.validate({ users: [{}, {}] });
```

The result would have errors on the attributes

- users.0.firstname
- users.1.firstname

This has also removed the `rules` prop and replaced it with a `validator` props that can implement different validators using external libraries. I have had a quick play with implementing a `zod` validator as well as using the built-in one.

Still a couple of things left todo

- [x] Implement and test validating an attribute
- [x] Refactor dot notation to remove complexity

Ref: #12 