### PR TITLE
fix: nested attribute errors

### DIFF
--- a/src/form.tsx
+++ b/src/form.tsx
@@ -143,8 +143,11 @@ export class Form<T extends Record<string, any>> extends React.Component<FormPro
    * Gets the first error message found for an attribute. Undefined will be
    * returned if there are not validation errors for the attribute.
    */
-  firstError = (attribute: string): string => {
-    return get(this.state.errors, [...attribute.split("."), "0"]);
+  firstError = (attribute: string): string | undefined => {
+    const attributeErrors = this.state.errors[attribute];
+    if (typeof attributeErrors !== "undefined") {
+      return attributeErrors[0];
+    }
   };
 
   /**

--- a/src/radio-group.tsx
+++ b/src/radio-group.tsx
@@ -19,7 +19,7 @@ export interface OptionType {
   value: string;
 }
 
-export interface RadioGroupProps extends BaseGroupProps<{ error: string }> {
+export interface RadioGroupProps extends BaseGroupProps<{ error?: string }> {
   /**
    * The options for this input
    */

--- a/tests/validation.spec.tsx
+++ b/tests/validation.spec.tsx
@@ -83,3 +83,30 @@ it("will validate array data", async () => {
   const attributeResult = await validator.validateAttribute("users.0.firstname", { users: [{}, {}] });
   expect(attributeResult).toStrictEqual(["Required"]);
 });
+
+const nestedValidator = createValidator({
+  "author.name": [
+    (formState) => {
+      if (!formState?.author?.name) {
+        return "Author name can not be blank";
+      }
+
+      return "";
+    },
+  ],
+});
+
+it("will validate nested validators", async () => {
+  const onSubmit = jest.fn();
+  render(
+    <Form initialValues={{ author: { name: "" } }} validator={nestedValidator} onSubmit={onSubmit}>
+      <Input attribute="author.name" />
+      <button>submit</button>
+    </Form>
+  );
+
+  await userEvent.click(screen.getByText("submit"));
+  await waitFor(() => screen.getByText("Author name can not be blank"));
+
+  expect(onSubmit).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
When validating nested attributes we are storing the attributes in a flat object with the of "author.name", when trying to get the error we are using dot notation and looking for `{author: { name: [] }}`.

Now we are storing and looking up using the flat object so nested attribute errors now work

Fixes-issue: #36