### PR TITLE
feat: allow return type ValidationFunction to be undefined

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -26,7 +26,7 @@ type ValidationOptions = {
  * the string is not empty then it will include a error message that will be
  * displayed to the user.
  */
-export type ValidationFunction<T> = (formState: T, options: ValidationOptions) => string;
+export type ValidationFunction<T> = (formState: T, options: ValidationOptions) => string | undefined;
 
 /**
  * A list of rules that will can be validated. The key is a dot notation that
@@ -104,7 +104,9 @@ export class Validator<T> {
   private applyFunction(attribute: string, path: string, value: any, data: T) {
     return this.rules[attribute]
       .map((validationFunction) => validationFunction(data, { attribute, path, value }))
-      .filter((item) => item);
+      .filter((item): item is string => {
+        return typeof item === "string" && item.length > 0;
+      });
   }
 }
 

--- a/tests/validation.spec.tsx
+++ b/tests/validation.spec.tsx
@@ -110,3 +110,27 @@ it("will validate nested validators", async () => {
 
   expect(onSubmit).not.toHaveBeenCalled();
 });
+
+it("will use a validation function that returns undefined", async () => {
+  const validator = createValidator({
+    userName: [
+      ({ userName }) => {
+        if (!userName) {
+          return "Error message";
+        }
+      },
+    ],
+  });
+
+  const result = await validator.validate({});
+  expect(result).toStrictEqual({ userName: ["Error message"] });
+});
+
+it("will use validation functions that are empty or undefined as valid", async () => {
+  const validator = createValidator({
+    userName: [() => "", () => undefined],
+  });
+
+  const result = await validator.validate({});
+  expect(result).toStrictEqual({});
+});


### PR DESCRIPTION
When crating a validation function the return type can now be undefined. When the validation function returns undefined or an empty string the validator will treat this rule as valid.

Ref: #40