### PR TITLE
test: add act to test that modify react state

### DIFF
--- a/tests/check-group.spec.tsx
+++ b/tests/check-group.spec.tsx
@@ -21,14 +21,14 @@ it("will render and submit with a checkbox attribute", async () => {
     </Form>
   );
 
-  await userEvent.click(getByLabelText("Check"));
-  await userEvent.click(getByText("Submit"));
+  await act(async () => userEvent.click(getByLabelText("Check")));
+  await act(async () => userEvent.click(getByText("Submit")));
 
   expect(onSubmit).toBeCalledTimes(1);
   expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { checkMe: true } }));
 
-  await userEvent.click(getByLabelText("Check"));
-  await userEvent.click(getByText("Submit"));
+  await act(async () => userEvent.click(getByLabelText("Check")));
+  await act(async () => userEvent.click(getByText("Submit")));
 
   expect(onSubmit).toBeCalledTimes(2);
   expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { checkMe: false } }));
@@ -50,7 +50,7 @@ it("will have a default value and submit", async () => {
     </Form>
   );
 
-  await userEvent.click(getByText("Submit"));
+  await act(async () => userEvent.click(getByText("Submit")));
   await waitFor(() => expect(onSubmit).toBeCalledTimes(1));
   expect(onSubmit).toBeCalledWith(
     expect.objectContaining({

--- a/tests/form-status.spec.tsx
+++ b/tests/form-status.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Form from "../src/form";
@@ -41,7 +41,10 @@ it("will start clean then go dirty when the user inputs a value", async () => {
   renderForm({ onSubmit, formContext });
 
   expect(formContext.current?.status).toBe("clean");
-  await userEvent.type(screen.getByLabelText("test-input"), "some value");
+  await act(async () => {
+    await userEvent.type(screen.getByLabelText("test-input"), "some value");
+  });
+
   await waitFor(() => expect(formContext.current?.status).toBe("dirty"));
 });
 
@@ -56,9 +59,12 @@ it("validate and submit", async () => {
   renderForm({ onSubmit, formContext, validator });
 
   expect(formContext.current?.status).toBe("clean");
-  await userEvent.type(screen.getByLabelText("test-input"), "some value");
 
-  userEvent.click(screen.getByText("submit"));
+  await act(async () => {
+    await userEvent.type(screen.getByLabelText("test-input"), "some value");
+    await userEvent.click(screen.getByText("submit"));
+  });
+
   await waitFor(() => expect(formContext.current?.status).toBe("validating"), { timeout: 5000 });
   validateResolve();
 
@@ -79,6 +85,6 @@ it("will have the error status", async () => {
   const formContext: ContextReference = { current: undefined };
   renderForm({ onSubmit, formContext, validator });
 
-  userEvent.click(screen.getByText("submit"));
+  await act(async () => await userEvent.click(screen.getByText("submit")));
   await waitFor(() => expect(formContext.current?.status).toBe("error"));
 });

--- a/tests/list-group.spec.tsx
+++ b/tests/list-group.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Form from "../src/form";
 import { ListGroup, ListOption } from "../src/list-group";
@@ -36,21 +36,28 @@ it("will render and submit with a radio list", async () => {
     </Form>
   );
 
-  await userEvent.click(getByText("Add Tag"));
-  await userEvent.click(getByText("Submit"));
+  await act(async () => {
+    await userEvent.click(getByText("Add Tag"));
+    await userEvent.click(getByText("Submit"));
+  });
 
   expect(onSubmit).toBeCalledTimes(1);
   expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { tags: [""] } }));
 
-  await userEvent.type(getByLabelText("Tag 1"), "Tag One");
-  await userEvent.click(getByText("Submit"));
+  await act(async () => {
+    await userEvent.type(getByLabelText("Tag 1"), "Tag One");
+    await userEvent.click(getByText("Submit"));
+  });
 
   expect(onSubmit).toBeCalledTimes(2);
   expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { tags: ["Tag One"] } }));
 
-  await userEvent.click(getByText("Add Tag"));
-  await userEvent.type(getByLabelText("Tag 2"), "Tag Two");
-  await userEvent.click(getByText("Submit"));
+  await act(async () => userEvent.click(getByText("Add Tag")));
+
+  await act(async () => {
+    await userEvent.type(getByLabelText("Tag 2"), "Tag Two");
+    await userEvent.click(getByText("Submit"));
+  });
 
   expect(onSubmit).toBeCalledTimes(3);
   expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { tags: ["Tag One", "Tag Two"] } }));

--- a/tests/radio-group.spec.tsx
+++ b/tests/radio-group.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Form from "../src/form";
 import { RadioGroup, RadioOption } from "../src/radio-group";
@@ -31,14 +31,18 @@ it("will render and submit with a radio list", async () => {
     </Form>
   );
 
-  await userEvent.click(getByLabelText("One"));
-  await userEvent.click(getByText("Submit"));
+  await act(async () => {
+    await userEvent.click(getByLabelText("One"));
+    await userEvent.click(getByText("Submit"));
+  });
 
   expect(onSubmit).toBeCalledTimes(1);
   expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { pickOne: "one" } }));
 
-  await userEvent.click(getByLabelText("Two"));
-  await userEvent.click(getByText("Submit"));
+  await act(async () => {
+    await userEvent.click(getByLabelText("Two"));
+    await userEvent.click(getByText("Submit"));
+  });
 
   expect(onSubmit).toBeCalledTimes(2);
   expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { pickOne: "two" } }));

--- a/tests/select-group.spec.tsx
+++ b/tests/select-group.spec.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { render, fireEvent, waitFor } from "@testing-library/react";
+import { render, fireEvent, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Form from "../src/form";
 import SelectGroup from "../src/select-group";
@@ -47,8 +47,10 @@ it("will render and submit stuff", async () => {
     </Form>
   );
 
-  fireEvent.change(getByLabelText("Select"), { target: { value: "two" } });
-  fireEvent.click(getByText("Submit"));
+  act(() => {
+    fireEvent.change(getByLabelText("Select"), { target: { value: "two" } });
+    fireEvent.click(getByText("Submit"));
+  });
 
   await waitFor(() => expect(onSubmit).toBeCalledTimes(1));
   expect(onSubmit).toBeCalledWith(
@@ -67,8 +69,10 @@ it("will render and submit multiple values", async () => {
     </Form>
   );
 
-  userEvent.selectOptions(getByLabelText("Select"), ["three"]);
-  fireEvent.click(getByText("Submit"));
+  await act(async () => {
+    await userEvent.selectOptions(getByLabelText("Select"), ["three"]);
+    fireEvent.click(getByText("Submit"));
+  });
 
   await waitFor(() => expect(onSubmit).toBeCalledTimes(1));
   expect(onSubmit).toBeCalledWith(

--- a/tests/validation.spec.tsx
+++ b/tests/validation.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Form from "../src/form";
@@ -35,7 +35,7 @@ it("will validate the data with a raw function", async () => {
     </Form>
   );
 
-  await userEvent.click(screen.getByText("submit"));
+  await act(async () => userEvent.click(screen.getByText("submit")));
   await waitFor(() => expect(screen.getByText("First name is required")).not.toBeNull());
 });
 
@@ -54,10 +54,10 @@ it("will validate after input delay", async () => {
     </Form>
   );
 
-  await userEvent.type(screen.getByLabelText("firstName"), "testing");
+  await act(async () => userEvent.type(screen.getByLabelText("firstName"), "testing"));
   await waitFor(() => expect(validateAttribute).toHaveBeenCalledTimes(1));
 
-  await userEvent.click(screen.getByText("submit"));
+  await act(async () => await userEvent.click(screen.getByText("submit")));
   await waitFor(() => expect(validate).toHaveBeenCalledTimes(1));
 });
 
@@ -105,7 +105,7 @@ it("will validate nested validators", async () => {
     </Form>
   );
 
-  await userEvent.click(screen.getByText("submit"));
+  await act(async () => userEvent.click(screen.getByText("submit")));
   await waitFor(() => screen.getByText("Author name can not be blank"));
 
   expect(onSubmit).not.toHaveBeenCalled();


### PR DESCRIPTION
Apparently `userEvent` is not wrapped in `act` like `fireEvent`. This wraps state changes in `act` to get rid of the console errors.