### PR TITLE
feat: add hooks for setting different attributes of different data types

### DIFF
--- a/src/check-group.tsx
+++ b/src/check-group.tsx
@@ -1,25 +1,15 @@
 import { FC } from "react";
-import { useFormContext } from "./form-context";
 import { AttributeHook } from "./attribute-hook";
 import { BaseGroupProps } from "./base-group-props";
+import { useBooleanAttribute } from "./use-attribute";
 
 export type CheckAttributeHook = AttributeHook<HTMLInputElement>;
 
 export const useCheckboxAttribute = (attribute: string): CheckAttributeHook => {
-  const formContext = useFormContext();
+  const { id, error, value: checked, set } = useBooleanAttribute(attribute, false);
 
-  return {
-    error: formContext.firstError(attribute),
-    props: {
-      id: attribute,
-      name: attribute,
-      type: "checkbox",
-      checked: Boolean(formContext.getAttribute(attribute)),
-      onChange: ({ target: { checked } }) => {
-        formContext.setAttribute(attribute, Boolean(checked));
-      },
-    },
-  };
+  const onChange: CheckAttributeHook["props"]["onChange"] = ({ target: { checked } }) => set(checked);
+  return { error, props: { id, name: attribute, type: "checkbox", checked, onChange } };
 };
 
 export interface CheckGroupProps {

--- a/src/dot-notation.ts
+++ b/src/dot-notation.ts
@@ -24,7 +24,12 @@ type ObjectMatch = {
  * Get a value from a object from a dot notation
  */
 export function get(object: ObjectType, notation: Notation): any {
-  return getAll(object, notation)?.[0]?.value || undefined;
+  const matches = getAll(object, notation);
+  if (matches.length === 0) {
+    return undefined;
+  }
+
+  return matches[0].value;
 }
 
 /**

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -135,7 +135,8 @@ export class Form<T extends Record<string, any>> extends React.Component<FormPro
    * Gets the value for a given attribute
    */
   getAttribute = (attribute: string, defaultValue: any = "") => {
-    return get(this.state.formState, attribute) || defaultValue;
+    const result = get(this.state.formState, attribute);
+    return typeof result !== "undefined" ? result : defaultValue;
   };
 
   /**

--- a/src/input-group.tsx
+++ b/src/input-group.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
-import { useFormContext } from "./form-context";
 import { AttributeHook } from "./attribute-hook";
 import { BaseGroupProps } from "./base-group-props";
+import { useStringAttribute } from "./use-attribute";
 
 export type TextAttributeHook = AttributeHook<HTMLInputElement>;
 
@@ -10,19 +10,10 @@ export type TextAttributeHook = AttributeHook<HTMLInputElement>;
  * the from context
  */
 export const useTextAttribute = (attribute: string): TextAttributeHook => {
-  const formContext = useFormContext<{}>();
+  const { id, error, value, set } = useStringAttribute(attribute, "");
 
-  return {
-    error: formContext.firstError(attribute),
-    props: {
-      id: attribute,
-      name: attribute,
-      value: formContext.getAttribute(attribute),
-      onChange: ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
-        formContext.setAttribute(attribute, value);
-      },
-    },
-  };
+  const onChange: TextAttributeHook["props"]["onChange"] = ({ target: { value } }) => set(value);
+  return { error, props: { id, name: attribute, value, onChange } };
 };
 
 /**

--- a/src/use-attribute.tsx
+++ b/src/use-attribute.tsx
@@ -1,0 +1,19 @@
+import { useFormContext } from "./form-context";
+
+export function createUseAttributeHook<T>(convert: (value: any) => T) {
+  return (attribute: string, defaultValue: T) => {
+    const { firstError, getAttribute, setAttribute } = useFormContext();
+
+    return {
+      id: attribute,
+      error: firstError(attribute),
+      value: getAttribute(attribute, defaultValue || ""),
+      set: (value: any) => setAttribute(attribute, convert(value)),
+    };
+  };
+}
+
+export const useAttribute = createUseAttributeHook<string>((value) => value);
+export const useStringAttribute = createUseAttributeHook<string>((value) => String(value));
+export const useDateAttribute = createUseAttributeHook<Date>((value) => new Date(value));
+export const useBooleanAttribute = createUseAttributeHook<boolean>((value) => Boolean(value));

--- a/tests/dot-notaion.spec.tsx
+++ b/tests/dot-notaion.spec.tsx
@@ -18,6 +18,16 @@ it("wont crash if we pass in undefined", () => {
   expect(get(undefined, "a.c.e")).toBeUndefined();
 });
 
+it("will return false value not the default value", () => {
+  const input = { a: false };
+  expect(get(input, "a")).toStrictEqual(false);
+});
+
+it("will return 0 value not the default value", () => {
+  const input = { a: 0 };
+  expect(get(input, "a")).toStrictEqual(0);
+});
+
 it("will work on an array", () => {
   const input = { a: { b: "value" } };
   const output = get(input, ["a", "b"]);
@@ -37,6 +47,20 @@ it("will set empty objects", () => {
   set(input, "a.b", "new value");
 
   expect(input.a.b).toBe("new value");
+});
+
+it("will set a false value", () => {
+  const input = { a: "testing" };
+  set(input, "a", false);
+
+  expect(input.a).toStrictEqual(false);
+});
+
+it("will set a number value", () => {
+  const input = { a: "testing" };
+  set(input, "a", 22);
+
+  expect(input.a).toStrictEqual(22);
 });
 
 it("will get all matching", () => {

--- a/tests/use-attribute.spec.tsx
+++ b/tests/use-attribute.spec.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+
+import { Form } from "../src/form";
+import { useBooleanAttribute, useStringAttribute } from "../src/use-attribute";
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return <Form onSubmit={jest.fn}>{children}</Form>;
+};
+
+const renderAttributeHook = (attribute: string, defaultValue: string) => {
+  return renderHook(() => useStringAttribute(attribute, defaultValue), { wrapper });
+};
+
+it("useAttribute will mount and update the base attribute hook", () => {
+  const { result } = renderAttributeHook("testing", "");
+
+  expect(result.current.value).toBe("");
+  act(() => result.current.set("Hello"));
+  expect(result.current.value).toBe("Hello");
+});
+
+test.each([
+  ["string", "string"],
+  [1, "1"],
+  [true, "true"],
+  [undefined, "undefined"],
+])("useAttribute setting %s is cast to a string and will be %s", (value, expected) => {
+  const { result } = renderAttributeHook("testing", "");
+  act(() => result.current.set(value));
+  expect(result.current.value).toStrictEqual(expected);
+});
+
+const renderBooleanAttributeHook = (attribute: string, defaultValue: boolean) => {
+  return renderHook(() => useBooleanAttribute(attribute, defaultValue), { wrapper });
+};
+
+test.each([
+  [true, true],
+  [false, false],
+  [1, true],
+  [0, false],
+  ["test", true],
+])("useBooleanAttribute setting %s is cast to a boolean be %s", (value, expected) => {
+  const { result } = renderBooleanAttributeHook("testing", false);
+  act(() => result.current.set(value));
+  expect(result.current.value).toStrictEqual(expected);
+});


### PR DESCRIPTION
Extracts the useTextAttribute and useCheckboxAttribute logic in to hooks that convert data type for a more generic use. The main struggle with HTML inputs is everything is a string. In a typed environment, this does not play well with things like checkboxes and date inputs.

This adds a `convert` function to the hook so we can convert input values into whatever data type we want. This will then get stored in the formState as that data type for use later.

```tsx
const { value, set } = useBooleanAttribute('checkMe', false);

// value === false
set(1)
// value === true
```

This also fixes and issue with the default value with `formContext.getAttribute`. Currently it will never return `false` or `0`, all we get is the default value. Now you can safely use true and false in your formState.