### PR TITLE
docs: sort out links in pr-template and contributing docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,8 +6,6 @@ Please include a summary of the change and which issue is fixed. Please also
 include relevant motivation and context. List any dependencies that are
 required for this change.
 
-Before you 
-
 -->
 
 Fixes # (issue)
@@ -29,8 +27,9 @@ Fixes # (issue)
 
 <!-- Please complete the checklist as best you can -->
 
-- [ ] My commits are formatted correctly
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
+- [ ] I have performed a self-review of my own code
+- [ ] I have requested review from the maintainers
+- [ ] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
+- [ ] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,11 @@ transparent as possible, whether it's:
 We use github to host code, to track issues and feature requests, as well as
 accept pull requests.
 
-There are two [milestones](../milestones) for this project. We have the
-backlog, this is tasks that have been reported and are out of scope for the
-current release. Then we have the current major release milestones, this is
-tasks that the core team will be looking to work on and get released in the
-current major version.
+There are two [milestones](https://github.com/AdeAttwood/ReactForm/milestones)
+for this project. We have the backlog, this is tasks that have been reported
+and are out of scope for the current release. Then we have the current major
+release milestones, this is tasks that the core team will be looking to work on
+and get released in the current major version.
 
 Anyone can work on any task they wish, the milestones are a way for us to
 convey or current direction for this project.
@@ -35,8 +35,9 @@ next release, all these issues will be closed.
 ## Any contributions you make will be under the BSD 3-Clause license
 
 In short, when you submit code changes, your submissions are understood to be
-under the same [BSD 3-Clause License](./LICENSE) that covers the project. Feel
-free to contact the maintainers if that's a concern.
+under the same [BSD 3-Clause
+License](https://github.com/AdeAttwood/ReactForm/blob/0.x/LICENSE) that covers
+the project. Feel free to contact the maintainers if that's a concern.
 
 ## Reporting bugs or requesting features
 


### PR DESCRIPTION
## Summary

Update the links in contributing docs. This is so when crating PR's there are links to the relevant docs in the checklists if users want more information.

## Type of change

<!-- Please remove any points that are not relevant for your pull request -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes -->

No tests required.

## Checklist:

<!-- Please complete the checklist as best you can -->

- [x] My commits are formatted correctly
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
