### PR TITLE
refactor: move all of the list logic into a hook

### DIFF
--- a/docs/pages/component-list-group.mdx
+++ b/docs/pages/component-list-group.mdx
@@ -15,13 +15,16 @@ import { ListGroup, ListOption, InputGroup } from "@adeattwood/react-form";
   {({ add }) => (
     <div>
       <ListOption>
-        {({ index }) => (
+        {({ index, remove }) => (
           <div key={index}>
             <InputGroup attribute={`tags.${index}`}>
               {({ props }) => (
                 <div>
                   <label htmlFor={props.id}>Tag {parseInt(index) + 1}</label>
                   <input {...props} />
+                  <button type="button" onClick={remove}>
+                    Remove {parseInt(index) + 1}
+                  </button>
                 </div>
               )}
             </InputGroup>

--- a/src/attribute-context.tsx
+++ b/src/attribute-context.tsx
@@ -10,6 +10,10 @@ export type AttributeContextType<T> = {
    * requests multiple options
    */
   options: T[];
+  /**
+   * A callback function that will remove an item from the options at the index
+   */
+  remove?: (index: number) => void;
 };
 
 /**

--- a/tests/list-group.spec.tsx
+++ b/tests/list-group.spec.tsx
@@ -13,17 +13,18 @@ it("will render and submit with a radio list", async () => {
         {({ add }) => (
           <div>
             <ListOption>
-              {({ index }) => (
-                <div key={index}>
-                  <InputGroup attribute={`tags.${index}`}>
-                    {({ props }) => (
-                      <div>
-                        <label htmlFor={props.id}>Tag {parseInt(index) + 1}</label>
-                        <input {...props} />
-                      </div>
-                    )}
-                  </InputGroup>
-                </div>
+              {({ index, remove }) => (
+                <InputGroup key={index} attribute={`tags.${index}`}>
+                  {({ props }) => (
+                    <div>
+                      <label htmlFor={props.id}>Tag {parseInt(index) + 1}</label>
+                      <input {...props} />
+                      <button type="button" onClick={remove}>
+                        Remove {parseInt(index) + 1}
+                      </button>
+                    </div>
+                  )}
+                </InputGroup>
               )}
             </ListOption>
             <button type="button" onClick={add}>
@@ -61,4 +62,12 @@ it("will render and submit with a radio list", async () => {
 
   expect(onSubmit).toBeCalledTimes(3);
   expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { tags: ["Tag One", "Tag Two"] } }));
+
+  await act(async () => {
+    await userEvent.click(getByText("Remove 1"));
+    await userEvent.click(getByText("Submit"));
+  });
+
+  expect(onSubmit).toBeCalledTimes(4);
+  expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { tags: ["Tag Two"] } }));
 });


### PR DESCRIPTION
## Summary

Implement the remove list item. Also abstracts the logic into a hook, so we don't have to use it as a render prop using the attribute context.

Fixes #38

## Type of change

<!-- Please remove any points that are not relevant for your pull request -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Please complete the checklist as best you can -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)
