### PR TITLE
feat: add onChange prop

### DIFF
--- a/src/form.tsx
+++ b/src/form.tsx
@@ -43,6 +43,11 @@ export interface FormProps<T extends {}> {
    */
   onSubmit: (params: { formState: T }) => any | Promise<any>;
   /**
+   * Callback that is called whenever an attribute is changed
+   */
+  onChange?: (context: ReturnType<Form<T>["getContextValue"]>) => void;
+  /**
+   *
    * TODO(ade): sort out prop with children
    */
   children: any;
@@ -158,6 +163,7 @@ export class Form<T extends Record<string, any>> extends React.Component<FormPro
     }
 
     this.setState({ formState, errors, status });
+    this.props.onChange?.(this.getContextValue());
   };
 
   /**

--- a/tests/on-change.spec.tsx
+++ b/tests/on-change.spec.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { render, screen, cleanup, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import Form from "../src/form";
+import Input from "./input-component";
+
+afterEach(cleanup);
+
+it("will call onChange when a attribute is changed", async () => {
+  const onChange = jest.fn();
+  const onSubmit = jest.fn();
+
+  render(
+    <Form onChange={onChange} onSubmit={onSubmit}>
+      <Input attribute="test-input" />
+    </Form>
+  );
+
+  await act(async () => {
+    await userEvent.type(screen.getByLabelText("test-input"), "A");
+  });
+
+  expect(onChange).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

Adds a new `onChange` prop that is called whenever an attribute is changed. It is currently called with the context value, so we have access to all the data and the submit function.

Fixes #94

## Type of change

<!-- Please remove any points that are not relevant for your pull request -->

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Written test with jest

## Checklist:

<!-- Please complete the checklist as best you can -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)
