### PR TITLE
chore: update the pr template to include ref not fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ required for this change.
 
 -->
 
-Fixes # (issue)
+Ref #(issue)
 
 ## Type of change
 


### PR DESCRIPTION
## Summary

Having fixes before the issue seems to close the issue when the PR gets merged. This is not what I want with the current workflow described in the contributing guidelines.

## Type of change

<!-- Please remove any points that are not relevant for your pull request -->

- [x] MEH

## How has this been tested?

We can wait and see if it works, I suppose.

## Checklist:

<!-- Please complete the checklist as best you can -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)
