### PR TITLE
On submit updates

### DIFF
--- a/docs/layouts/main.tsx
+++ b/docs/layouts/main.tsx
@@ -35,6 +35,10 @@ const navData: LinkSetProps[] = [
         title: "Validation",
         href: "/validation",
       },
+      {
+        title: "Submitting",
+        href: "/submit",
+      },
     ],
   },
   {

--- a/docs/pages/submit.mdx
+++ b/docs/pages/submit.mdx
@@ -1,0 +1,51 @@
+import Layout from "../layouts/main";
+
+export const meta = {
+  title: "Submit",
+};
+
+# Submit
+
+Submit the form is done with the onSubmit prop. This function takes in the form
+state, so you can send the data to your server. It will only be called if the
+validation passes, so you will not be sending bad data to the server. The
+function can be async, it will be awaited when the form is submitted. While the
+promise is resolving, the form status will be set to "submitting".
+
+To add errors to the form state if the server request fails, you can throw an
+error that has errorBag property on it. The contents of this will be set as the
+form errors, removing any errors that are currently there.
+
+```js
+const onSubmit = ({ formState }) => {
+  return fetch("/create-post", { 
+    method: "POST",
+    body: JSON.stringify(formState),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
+  .then((res) => res.json())
+  .then((res) => {
+    if (res.errorBag) {
+      throw res;
+    }
+
+    // Do something with the result
+  });
+};
+```
+
+Native form submissions can be done by calling the `submit` function on the DOM
+node. This can be called by using the event that is passed into the `onSubmit`
+callback.
+
+```js
+const onSubmit = ({ event }) => {
+  event.target.method = "POST";
+  event.target.submit();
+}
+```
+
+
+export default ({ children }) => <Layout meta={meta}>{children}</Layout>

--- a/docs/pages/validation.mdx
+++ b/docs/pages/validation.mdx
@@ -67,4 +67,36 @@ const validator = createValidator({
 });
 ```
 
+Validation objects can also be cloned, so you can add extra rules. This can be
+used to add extra validation that will only run on the server. On the client
+validator you will get all the validation rules that can be run in the browser,
+in the server validator you get all the rules from the client and extra ones
+that can access databases to-do extra checks.
+
+```js
+const clientValidator = createValidator({
+  email: [(({ email }) => isEmpty(email) && "Email cannot be blank")]
+})
+
+const serverValidator = clientValidator
+  .clone()
+  .addRule('email', ({ email }) => isInDb(email) && "Email must be unique")
+```
+
+Async validators are also allowed if you need to await http or database calls
+when building validators.
+
+```js
+const validator = createValidator({
+  url: [
+    async ({ url }) => {
+      const result = await fetch(url, { method: "HEAD" });
+      if (result.status >= 400) {
+        return `${url} is not accessible`;
+      }
+    },
+  ],
+});
+```
+
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -41,7 +41,7 @@ export interface FormProps<T extends {}> {
   /**
    * TODO(ade): Sort out this doc
    */
-  onSubmit: (params: { formState: T }) => any | Promise<any>;
+  onSubmit: (params: { formState: T; event: React.SyntheticEvent<HTMLFormElement> }) => any | Promise<any>;
   /**
    * Callback that is called whenever an attribute is changed
    */
@@ -122,7 +122,7 @@ export class Form<T extends Record<string, any>> extends React.Component<FormPro
    * This will validate the form and call the `onSubmit` props if there are no errors.
    * If the form is invalid then the state will be populated with the errors.
    */
-  submit = async (event: React.SyntheticEvent) => {
+  submit = async (event: React.SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
     this.setState({ status: "validating" });
     const errors = await this.props.validator?.validate(this.state.formState);
@@ -131,8 +131,10 @@ export class Form<T extends Record<string, any>> extends React.Component<FormPro
       return this.setState({ errors, status });
     }
 
+    event.currentTarget;
+
     this.setState({ status: "submitting" });
-    await this.props.onSubmit({ formState: this.state.formState });
+    await this.props.onSubmit({ formState: this.state.formState, event });
     this.setState({ status });
   };
 

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -67,6 +67,11 @@ export interface FormProps<T extends {}> {
    * TODO(ade): sort out prop with children
    */
   children: any;
+  /**
+   * Errors for the form to be populated with with initializing the form. This
+   * can be used to populated errors from the server on first page load.
+   */
+  errors?: ErrorBag;
 }
 
 /**
@@ -119,7 +124,7 @@ export class Form<T extends Record<string, any>> extends React.Component<FormPro
     /**
      * The internal status of the form
      */
-    status: "clean",
+    status: this.getErrorStatus(this.props.errors || {}),
     /**
      * The form state of the current form
      */
@@ -129,7 +134,7 @@ export class Form<T extends Record<string, any>> extends React.Component<FormPro
      * value is an array of string that are the error messages returned from the
      * validation functions in the rules.
      */
-    errors: {},
+    errors: this.props.errors || {},
   };
 
   /**

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -9,6 +9,22 @@ import { get, set } from "./dot-notation";
  */
 export type FormStatus = "clean" | "error" | "dirty" | "validating" | "submitting";
 
+type OnSubmitParams<T> = {
+  /**
+   * The current state of the form at submit time
+   */
+  formState: T;
+  /**
+   * The raw React submit event passed from the React onSubmit callback
+   */
+  event: React.SyntheticEvent<HTMLFormElement>;
+};
+
+/**
+ * Function callback that will be called when the form is submitted
+ */
+export type OnSubmitFunction<T = {}> = (params: OnSubmitParams<T>) => any | Promise<any>;
+
 export interface FormProps<T extends {}> {
   /**
    * The initial form state
@@ -41,7 +57,7 @@ export interface FormProps<T extends {}> {
   /**
    * TODO(ade): Sort out this doc
    */
-  onSubmit: (params: { formState: T; event: React.SyntheticEvent<HTMLFormElement> }) => any | Promise<any>;
+  onSubmit: OnSubmitFunction<T>;
   /**
    * Callback that is called whenever an attribute is changed
    */

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -57,6 +57,16 @@ export class Validator<T> {
   }
 
   /**
+   * Creates a new validator with all the same rules.
+   */
+  clone() {
+    // Shallow clone the rules into the new validators so the we are not
+    // passing along the reference. This is so the `addRule` function will not
+    // add to both validators.
+    return new Validator<T>({ ...this.rules });
+  }
+
+  /**
    * Add a new rule to the validator. If a rules already exists for the
    * attribute then the function will be added to it.
    */

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -111,6 +111,19 @@ export class Validator<T> {
 }
 
 /**
+ * Tests to see if an object can be
+ */
+export function isErrorBagObject(object: any): object is { errorBag: ErrorBag } {
+  return (
+    object &&
+    typeof object === "object" &&
+    "errorBag" in object &&
+    object.errorBag &&
+    typeof object.errorBag === "object"
+  );
+}
+
+/**
  * Helper function to create the validator functional style
  */
 export function createValidator<T = any>(rules: Rules<T> = {}) {

--- a/tests/form-error-init.spec.tsx
+++ b/tests/form-error-init.spec.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import Form from "../src/form";
+import Input from "./input-component";
+
+it("will display errors when they are passed in via props", async () => {
+  const onSubmit = jest.fn();
+
+  render(
+    <Form initialValues={{ firstName: "" }} onSubmit={onSubmit} errors={{ firstName: ["This error"] }}>
+      <Input attribute="firstName" />
+      <button>submit</button>
+    </Form>
+  );
+
+  screen.getByText("This error");
+});

--- a/tests/form-status.spec.tsx
+++ b/tests/form-status.spec.tsx
@@ -20,14 +20,14 @@ const createPromise = () => {
 };
 
 type ContextReference = { current: ReturnType<typeof useFormContext> | undefined };
-const renderForm = ({ onSubmit, validator, formContext }: any) => {
+const renderForm = ({ onSubmit, validator, formContext, errors }: any) => {
   const MockComponent = () => {
     formContext.current = useFormContext();
     return null;
   };
 
   render(
-    <Form initialValues={{}} validator={validator} onSubmit={onSubmit}>
+    <Form initialValues={{}} validator={validator} onSubmit={onSubmit} errors={errors}>
       <MockComponent />
       <Input attribute="test-input" />
       <button>submit</button>
@@ -87,4 +87,18 @@ it("will have the error status", async () => {
 
   await act(async () => await userEvent.click(screen.getByText("submit")));
   await waitFor(() => expect(formContext.current?.status).toBe("error"));
+});
+
+it("will have the error status when errors are passed in as props", async () => {
+  const onSubmit = jest.fn();
+  const formContext: ContextReference = { current: undefined };
+  renderForm({ onSubmit, formContext, errors: { "test-input": ["An error"] } });
+  expect(formContext.current?.status).toBe("error");
+});
+
+it("will not have an error status if an empty error object is passed in", async () => {
+  const onSubmit = jest.fn();
+  const formContext: ContextReference = { current: undefined };
+  renderForm({ onSubmit, formContext, errors: {} });
+  expect(formContext.current?.status).toBe("clean");
 });

--- a/tests/on-submit.spec.tsx
+++ b/tests/on-submit.spec.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 
 import Form, { OnSubmitFunction } from "../src/form";
 import Input from "./input-component";
+import { useFormContext } from "../src/form-context";
 
 afterEach(cleanup);
 
@@ -25,4 +26,50 @@ it("will call onSubmit", async () => {
   });
 
   expect(onSubmitMock).toHaveBeenCalled();
+});
+
+it("will set the errors from the onSubmit callback", async () => {
+  const onSubmit: OnSubmitFunction = () => {
+    throw {
+      errorBag: { "test-input": ["This is a error from the errors"] },
+    };
+  };
+
+  render(
+    <Form onSubmit={onSubmit}>
+      <Input attribute="test-input" />
+      <button>Submit</button>
+    </Form>
+  );
+
+  await act(async () => {
+    await userEvent.click(screen.getByText("Submit"));
+  });
+
+  expect(screen.getByText("This is a error from the errors"));
+});
+
+it("will set the status to clean if the errors are cleared", async () => {
+  const onSubmit: OnSubmitFunction = () => {
+    throw { errorBag: {} };
+  };
+
+  function StatusComponent() {
+    const { status } = useFormContext();
+    return <span>Status: {status}</span>;
+  }
+
+  render(
+    <Form onSubmit={onSubmit}>
+      <Input attribute="test-input" />
+      <StatusComponent />
+      <button>Submit</button>
+    </Form>
+  );
+
+  await act(async () => {
+    await userEvent.click(screen.getByText("Submit"));
+  });
+
+  expect(screen.getByText("Status: clean"));
 });

--- a/tests/on-submit.spec.tsx
+++ b/tests/on-submit.spec.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { render, screen, cleanup, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import Form, { OnSubmitFunction } from "../src/form";
+import Input from "./input-component";
+
+afterEach(cleanup);
+
+it("will call onSubmit", async () => {
+  const onSubmitMock = jest.fn();
+  // Split out the onSubmit callback so we can explicity type it like the
+  // external API to tests the types.
+  const onSubmit: OnSubmitFunction = () => onSubmitMock();
+
+  render(
+    <Form onSubmit={onSubmit}>
+      <Input attribute="test-input" />
+      <button>Submit</button>
+    </Form>
+  );
+
+  await act(async () => {
+    await userEvent.click(screen.getByText("Submit"));
+  });
+
+  expect(onSubmitMock).toHaveBeenCalled();
+});

--- a/tests/validation.spec.tsx
+++ b/tests/validation.spec.tsx
@@ -134,3 +134,12 @@ it("will use validation functions that are empty or undefined as valid", async (
   const result = await validator.validate({});
   expect(result).toStrictEqual({});
 });
+
+it("will take a async function in the validation", async () => {
+  const validator = createValidator({
+    userName: [() => Promise.resolve("This is an error")],
+  });
+
+  const result = await validator.validate({});
+  expect(result).toStrictEqual({ userName: ["This is an error"] });
+});

--- a/tests/validation.spec.tsx
+++ b/tests/validation.spec.tsx
@@ -143,3 +143,18 @@ it("will take a async function in the validation", async () => {
   const result = await validator.validate({});
   expect(result).toStrictEqual({ userName: ["This is an error"] });
 });
+
+it("will clone a validator", async () => {
+  const validatorOne = createValidator({
+    userName: [() => Promise.resolve("This is an error")],
+  });
+
+  const validatorTwo = validatorOne.clone();
+  validatorTwo.addRule("email", () => "Email has an error");
+
+  const resultOne = await validatorOne.validate({});
+  expect(resultOne).toStrictEqual({ userName: ["This is an error"] });
+
+  const resultTwo = await validatorTwo.validate({});
+  expect(resultTwo).toStrictEqual({ userName: ["This is an error"], email: ["Email has an error"] });
+});


### PR DESCRIPTION
## Summary

Multiple updates for integrating with Rimix Run framework. Most of this is improving the way we can add errors from the server when doing server side validation.

---

[feat: pass the event to the onSubmit callback](https://github.com/AdeAttwood/ReactForm/commit/a8bbda8e76f420bee2906fb8e55177e8984bcbfd)

Now when you are in the on submit function you can access the React DOM
event from in the `event` prop passed in to the function.

```js
function onSubmit({ event }) {
  const target = event.currentTarget
}
```

This can be used to access the target of the form if you wish to some
native posting.

---

[feat: split out the OnSubmitFunction type](https://github.com/AdeAttwood/ReactForm/commit/945ddb3bc21f05fbcd612da955b4b34d2af21f76) 

This is so you can split out the onSubmit callback in your application
and not have to write out a hole type to get code completion.

There are not functional changes to this is a quality of live DX change

---

[feat: allow errors to be set from the onSubmit callback](https://github.com/AdeAttwood/ReactForm/commit/03a2aeff5daf59fea430db5b6c7d89078c530fd0) 

Now when an error is thrown from the `onSubmit` callback if the object
contains an `errorBag` property the contents of that property will be
interpreted as an "ErrorBag" and set as the errors. The status will also
be updated with the correct status for the errors being set.

```js
const onSubmit = () => {
  throw { errorBag: { attributeOne: ["List of error messages"] } };
}
```

This is useful for when server side validation fails and you want to
update the UI for the user.

---

[feat: allow a validation function to be async](https://github.com/AdeAttwood/ReactForm/commit/db74ad230a2226525af2542f8cad482febbde783) 

This is so we can use async code in the validators, this comes in handy
for making network requests or accessing a database in data validation.

```js
const validator = createValidator({
  email: [
    async ({ email }) => {
      const exists = await users.exists({ email });
      if (exists) {
        return 'Email address must be unique';
      }
    }
  ],
});
```

---

[feat: add validator.clone() function](https://github.com/AdeAttwood/ReactForm/commit/4e3b6cb2904be16fe5b79d6034d0d14a8635c354) 

This function will create a new validator with all the rules copied
over. This is so we can create client and server side validators with
minimal code duplication.

```js
const clientValidator = createValidator({
  email: [(({ email }) => isEmpty(email) && "Email cannot be blank")]
})

const serverValidator = clientValidator
  .clone()
  .addRule('email', ({ email }) => isInDb(email) && "Email must be unique")
```

In this example we have two validators one for the server and one for
the client. The client validator has all the code that can only run on
the client and the server one has all the validators. This is code that
can only run on the server and the client validation to ensure the user
done not skip it.

## Type of change

<!-- Please remove any points that are not relevant for your pull request -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this been tested?

Unit tests with jest and I have been using in while playing with a Remix application

## Checklist:

<!-- Please complete the checklist as best you can -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)
