### PR TITLE
ci: dont publish to NPM if the release fails

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -25,3 +26,10 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  fail:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Fail
+        run: echo "The release must pass for this to run" && exit 1


### PR DESCRIPTION
## Summary

We are using the `workflow_run` action to publish a build to NPM when a release is complete. This is also running when the release workflow fails.

Now we are using a conditional jobs to only publish the package if the release we successful.

I have added an extra job to fail the publish if the release fails so we get the correct statuses and it dose not look like the publish passes because no jobs have run.

Ref: #95

## Type of change

<!-- Please remove any points that are not relevant for your pull request -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

It has not, we will have to wait and see. Can't really test this without failing a publishing.

## Checklist:

<!-- Please complete the checklist as best you can -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)
