### PR TITLE
test: fail the tests if any console errors or warnings are displayed

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -128,7 +128,7 @@ export default {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ["./jest.setup.ts"],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,35 @@
+const consoleErrorMock = jest.spyOn(console, "error");
+const consoleWarnMock = jest.spyOn(console, "warn");
+
+function getMessageForMock(prefix: string, calls: Array<Array<string>>) {
+  const messages: { [k: string]: number } = {};
+  for (const [message] of calls) {
+    if (!(message in messages)) {
+      messages[message] = 0;
+    }
+
+    messages[message]++;
+  }
+
+  return Object.entries(messages)
+    .map(([message, count]) => `${prefix} (${count}x): ${message}`)
+    .join("\n")
+    .trim();
+}
+
+beforeEach(() => {
+  consoleErrorMock.mockReset();
+  consoleWarnMock.mockReset();
+});
+afterAll(() => {
+  consoleErrorMock.mockRestore();
+  consoleWarnMock.mockRestore();
+});
+
+afterEach(() => {
+  const errors = getMessageForMock("ERROR", consoleErrorMock.mock.calls);
+  const warnings = getMessageForMock("WARNING", consoleWarnMock.mock.calls);
+  if (errors || warnings) {
+    throw new Error(`Console must not throw errors or warnings\n\n${errors}\n${warnings}`);
+  }
+});


### PR DESCRIPTION
## Summary

When running the tests, there is no way to fail the tests if invalid props, or we don't wrap state updates in act. Due to this, we are failing the tests if any output is displayed via `console.error` or `console.warn`

No issues referenced

## Type of change

<!-- Please remove any points that are not relevant for your pull request -->

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Not really been tested, I did put a `console.error` in one of the tests and it failed.

## Checklist:

<!-- Please complete the checklist as best you can -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)
