### PR TITLE
feat: implement reorder on a list attribute

### DIFF
--- a/src/attribute-context.tsx
+++ b/src/attribute-context.tsx
@@ -14,6 +14,11 @@ export type AttributeContextType<T> = {
    * A callback function that will remove an item from the options at the index
    */
   remove?: (index: number) => void;
+  /**
+   * A callback that will reorder the options in the list. This will only apply
+   * to a list group input
+   */
+  reorder?: (from: number, to: number) => void;
 };
 
 /**

--- a/src/list-group.tsx
+++ b/src/list-group.tsx
@@ -47,13 +47,21 @@ export function useListAttribute<T>(attribute: string, newItem: () => T) {
     }
   };
 
-  return { id, error, value, set, add, remove };
+  const reorder = (from: number, to: number) => {
+    const newValue = [...value];
+    const [removed] = newValue.splice(from, 1);
+    newValue.splice(to, 0, removed);
+
+    set(newValue);
+  };
+
+  return { id, error, value, set, add, remove, reorder };
 }
 
 export const ListGroup: FC<ListGroupProps> = ({ children, attribute, newItem }) => {
-  const { value: options, add, remove } = useListAttribute(attribute, newItem || defaultNewItem);
+  const { value: options, add, remove, reorder } = useListAttribute(attribute, newItem || defaultNewItem);
 
-  return React.createElement(AttributeContextProvider, { attribute, options, remove }, children({ add }));
+  return React.createElement(AttributeContextProvider, { attribute, options, remove, reorder }, children({ add }));
 };
 
 ListGroup.defaultProps = {

--- a/tests/list-group.spec.tsx
+++ b/tests/list-group.spec.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { act, render } from "@testing-library/react";
+import { act, render, renderHook } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Form from "../src/form";
-import { ListGroup, ListOption } from "../src/list-group";
+import { ListGroup, ListOption, useListAttribute } from "../src/list-group";
 import { InputGroup } from "../src/input-group";
 
 it("will render and submit with a radio list", async () => {
@@ -70,4 +70,25 @@ it("will render and submit with a radio list", async () => {
 
   expect(onSubmit).toBeCalledTimes(4);
   expect(onSubmit).toBeCalledWith(expect.objectContaining({ formState: { tags: ["Tag Two"] } }));
+});
+
+it("will reorder the items", async () => {
+  const initialValues = { myList: ["One", "Two", "Three"] };
+  const hook = renderHook(() => useListAttribute("myList", () => ""), {
+    wrapper: ({ children }: any) => {
+      return (
+        <Form onSubmit={jest.fn} initialValues={initialValues}>
+          {children}
+        </Form>
+      );
+    },
+  });
+
+  expect(hook.result.current.value).toStrictEqual(["One", "Two", "Three"]);
+
+  await act(async () => {
+    hook.result.current.reorder(0, 3);
+  });
+
+  expect(hook.result.current.value).toStrictEqual(["Two", "Three", "One"]);
 });


### PR DESCRIPTION
## Summary

You can now reorder the values of a list attribute. The `useListAttribute` hook how has a reorder function that you can use to provide a from and to index.

```tsx
const { reorder } = useListAttribute("myList", () => "");

reorder(0, 3);
```

The above example will move the the item at index 0 to index 3;

Ref: #144

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Unit tests

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)