### PR TITLE
Form validation updates

### DIFF
--- a/src/form.tsx
+++ b/src/form.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { get, set } from "./dot-notation";
 import { FormContext } from "./form-context";
-import { ErrorBag, isErrorBagObject } from "./validator";
+import { ErrorBag } from "./validator";
 
 /**
  * All the available values that the status of the form could be
@@ -153,17 +153,8 @@ export class Form<T extends Record<string, any>> extends React.Component<FormPro
     }
 
     this.setState({ status: "submitting" });
-
-    try {
-      await this.props.onSubmit({ formState: this.state.formState, event });
-      this.setState({ status });
-    } catch (error) {
-      if (isErrorBagObject(error)) {
-        return this.setErrors(error.errorBag);
-      }
-
-      this.setState({ status: "error" });
-    }
+    const result = await this.props.onSubmit({ formState: this.state.formState, event });
+    this.setErrors(typeof result === "object" ? result : {});
   };
 
   /**

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -146,9 +146,9 @@ export class Form<T extends Record<string, any>> extends React.Component<FormPro
   submit = async (event: React.SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
     this.setState({ status: "validating" });
-    const errors = await this.props.validator?.validate(this.state.formState);
-    const status = this.getErrorStatus(errors || {});
-    if (errors && status === "error") {
+    const errors = await this.validate(this.state.formState);
+    const status = this.getErrorStatus(errors);
+    if (status === "error") {
       return this.setState({ errors, status });
     }
 
@@ -266,6 +266,14 @@ export class Form<T extends Record<string, any>> extends React.Component<FormPro
     return await fun(attribute, formState);
   };
 
+  validate = async (formState: T): Promise<ErrorBag> => {
+    if (!this.props.validator?.validate) {
+      return {};
+    }
+
+    return await this.props.validator.validate(formState);
+  };
+
   /**
    * Get if the error bag has errors or is valid. In this case it will return
    * "clean" to indicate the form is valid.
@@ -279,13 +287,16 @@ export class Form<T extends Record<string, any>> extends React.Component<FormPro
    */
   private getContextValue = () => {
     return {
-      status: this.state.status,
-      formState: this.state.formState,
       errors: this.state.errors,
       firstError: this.firstError,
+      formState: this.state.formState,
       getAttribute: this.getAttribute,
       setAttribute: this.setAttribute,
+      setErrors: this.setErrors,
+      status: this.state.status,
       submit: this.submit,
+      validate: this.validate,
+      validateAttribute: this.validateAttribute,
     };
   };
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -128,19 +128,6 @@ export class Validator<T> {
 }
 
 /**
- * Tests to see if an object can be
- */
-export function isErrorBagObject(object: any): object is { errorBag: ErrorBag } {
-  return (
-    object &&
-    typeof object === "object" &&
-    "errorBag" in object &&
-    object.errorBag &&
-    typeof object.errorBag === "object"
-  );
-}
-
-/**
  * Helper function to create the validator functional style
  */
 export function createValidator<T = any>(rules: Rules<T> = {}) {

--- a/tests/form-context.spec.tsx
+++ b/tests/form-context.spec.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+
+import { Form, useFormContext, createValidator } from "../src";
+
+it("will allow you to validate the form from the context", async () => {
+  const onSubmit = jest.fn();
+
+  const validator = createValidator({ test: [() => "I will always fail"] });
+
+  const { result } = renderHook(() => useFormContext(), {
+    wrapper: ({ children }) => (
+      <Form onSubmit={onSubmit} validator={validator}>
+        {children}
+      </Form>
+    ),
+  });
+
+  const errors = await result.current.validate(result.current.formState);
+  expect(errors).toStrictEqual({ test: ["I will always fail"] });
+
+  const attributeErrors = await result.current.validateAttribute("test-1", result.current.formState);
+  expect(attributeErrors).toHaveLength(0);
+
+  expect(result.current.status).toBe("clean");
+  await act(async () => result.current.setErrors(errors));
+  expect(result.current.status).toBe("error");
+});

--- a/tests/form-context.spec.tsx
+++ b/tests/form-context.spec.tsx
@@ -1,7 +1,7 @@
+import { act, renderHook } from "@testing-library/react";
 import React from "react";
-import { renderHook, act } from "@testing-library/react";
 
-import { Form, useFormContext, createValidator } from "../src";
+import { createValidator, Form, useFormContext } from "../src";
 
 it("will allow you to validate the form from the context", async () => {
   const onSubmit = jest.fn();

--- a/tests/form-status.spec.tsx
+++ b/tests/form-status.spec.tsx
@@ -66,7 +66,7 @@ it("validate and submit", async () => {
   });
 
   await waitFor(() => expect(formContext.current?.status).toBe("validating"), { timeout: 5000 });
-  validateResolve();
+  validateResolve({});
 
   await waitFor(() => expect(formContext.current?.status).toBe("submitting"), { timeout: 5000 });
   onSubmitResolve();

--- a/tests/on-submit.spec.tsx
+++ b/tests/on-submit.spec.tsx
@@ -30,9 +30,7 @@ it("will call onSubmit", async () => {
 
 it("will set the errors from the onSubmit callback", async () => {
   const onSubmit: OnSubmitFunction = () => {
-    throw {
-      errorBag: { "test-input": ["This is a error from the errors"] },
-    };
+    return { "test-input": ["This is a error from the errors"] };
   };
 
   render(
@@ -51,7 +49,7 @@ it("will set the errors from the onSubmit callback", async () => {
 
 it("will set the status to clean if the errors are cleared", async () => {
   const onSubmit: OnSubmitFunction = () => {
-    throw { errorBag: {} };
+    return {};
   };
 
   function StatusComponent() {

--- a/tests/validation.spec.tsx
+++ b/tests/validation.spec.tsx
@@ -39,7 +39,7 @@ it("will validate the data with a raw function", async () => {
 });
 
 it("will validate after input delay", async () => {
-  const validate = jest.fn();
+  const validate = jest.fn(async () => ({}));
   const validateAttribute = jest.fn(async () => []);
 
   render(


### PR DESCRIPTION
## Summary

**Ditch the exception idea from the `onSubmit` callback**

This is a really bad API for so many reasons. Throwing errors that are not actual `Error`  classes is in general a bad idea, they do not have all the standard props like `stack` or `message`.

Coding errors inside the `onSubmit` function get hidden and makes debugging very hard. Because all exceptions are getting caught and treated as an `ErrorBag` this leads to unexpected behaviour.

Now the developer must explicitly return the `ErrorBag` from the `onSubmit` callback. This does not only clean up the code in ReactForm but leads to a better developer experience while debugging.

**Expose validate, validateAttribute and setErrors to the context**

This is to make the context and state management more flexible. This comes in handy when you have larger forms when nested context. You can now validate sections of the form independently.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Even though this is tetchily a breaking change, I don't think it needs a major version bump as we are still in the alpha stage of the package.

## How has this been tested?

Unit tests

## Checklist:

<!-- Please complete the checklist as best you can -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)
