### PR TITLE
chore: add simple-import-sort eslint plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,12 +14,14 @@ module.exports = {
     "plugin:react-hooks/recommended",
     "plugin:react/recommended",
   ],
-  plugins: ["react", "prettier"],
+  plugins: ["react", "prettier", "simple-import-sort"],
   settings: {
     jsdoc: { mode: "typescript" },
     react: { version: "detect" },
   },
   rules: {
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
     "@next/next/no-html-link-for-pages": ["error", "docs/pages/"],
     "react/prop-types": "off",
     "@typescript-eslint/no-explicit-any": "off",

--- a/docs/components/code.spec.tsx
+++ b/docs/components/code.spec.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+import React from "react";
 
 import Code from "./code";
 

--- a/docs/components/code.tsx
+++ b/docs/components/code.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import Highlight, { defaultProps, Language } from "prism-react-renderer";
 import theme from "prism-react-renderer/themes/github";
+import React from "react";
 
 function Code({ children, className }: any) {
   const language = className?.replace(/language-/, "") as Language;

--- a/docs/components/mdx-components.spec.tsx
+++ b/docs/components/mdx-components.spec.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+import React from "react";
 
 import components from "./mdx-components";
 

--- a/docs/components/mdx-components.tsx
+++ b/docs/components/mdx-components.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import Code from "./code";
 
 const components = {

--- a/docs/components/mdx-provider.tsx
+++ b/docs/components/mdx-provider.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { MDXProvider as ReactMDXProvider } from "@mdx-js/react";
+import React from "react";
 
 import components from "./mdx-components";
 

--- a/docs/layouts/main.spec.tsx
+++ b/docs/layouts/main.spec.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+import React from "react";
 
 import Main from "./main";
 

--- a/docs/layouts/main.tsx
+++ b/docs/layouts/main.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import Head from "next/head";
 import Link from "next/link";
+import React from "react";
 
 import logo from "../assets/logo.svg";
 import styles from "./main.module.scss";
-import Head from "next/head";
 
 interface LinkSetProps {
   title: string;

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import MDXProvider from "../components/mdx-provider";
-import type { AppProps } from "next/app";
-
 import "../styles/light.scss";
+
+import type { AppProps } from "next/app";
+import React from "react";
+
+import MDXProvider from "../components/mdx-provider";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (

--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -1,5 +1,5 @@
+import Document, { Head, Html, Main, NextScript } from "next/document";
 import React from "react";
-import Document, { Html, Head, Main, NextScript } from "next/document";
 
 class MyDocument extends Document {
   render() {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.32.1",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-simple-import-sort": "^10.0.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",

--- a/src/check-group.tsx
+++ b/src/check-group.tsx
@@ -1,4 +1,5 @@
 import { FC } from "react";
+
 import { AttributeHook } from "./attribute-hook";
 import { BaseGroupProps } from "./base-group-props";
 import { useBooleanAttribute } from "./use-attribute";

--- a/src/form-context.tsx
+++ b/src/form-context.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import Form from "./form";
 
 export type FormContextType<T extends {}> = ReturnType<Form<T>["getContextValue"]>;

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { FormContext } from "./form-context";
 
-import { ErrorBag, isErrorBagObject } from "./validator";
 import { get, set } from "./dot-notation";
+import { FormContext } from "./form-context";
+import { ErrorBag, isErrorBagObject } from "./validator";
 
 /**
  * All the available values that the status of the form could be

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,5 @@ export * from "./input-group";
 export * from "./list-group";
 export * from "./radio-group";
 export * from "./select-group";
-export * from "./validator";
 export * from "./use-attribute";
+export * from "./validator";

--- a/src/input-group.tsx
+++ b/src/input-group.tsx
@@ -1,4 +1,5 @@
 import { FC } from "react";
+
 import { AttributeHook } from "./attribute-hook";
 import { BaseGroupProps } from "./base-group-props";
 import { useStringAttribute } from "./use-attribute";

--- a/src/list-group.tsx
+++ b/src/list-group.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from "react";
+
 import { AttributeContextProvider, useAttributeContext } from "./attribute-context";
 import { BaseGroupProps } from "./base-group-props";
 import { createUseAttributeHook } from "./use-attribute";

--- a/src/radio-group.tsx
+++ b/src/radio-group.tsx
@@ -1,8 +1,9 @@
 import React, { FC } from "react";
-import { useFormContext } from "./form-context";
+
 import { AttributeContextProvider, useAttributeContext } from "./attribute-context";
 import { AttributeHook } from "./attribute-hook";
 import { BaseGroupProps } from "./base-group-props";
+import { useFormContext } from "./form-context";
 
 export type RadioAttributeHook = AttributeHook<HTMLInputElement>;
 

--- a/src/select-group.tsx
+++ b/src/select-group.tsx
@@ -1,4 +1,5 @@
 import { FC } from "react";
+
 import { AttributeHook } from "./attribute-hook";
 import { BaseGroupProps } from "./base-group-props";
 import { useFormContext } from "./form-context";

--- a/tests/check-group.spec.tsx
+++ b/tests/check-group.spec.tsx
@@ -1,8 +1,9 @@
-import React from "react";
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import Form from "../src/form";
+import React from "react";
+
 import CheckGroup from "../src/check-group";
+import Form from "../src/form";
 import createValidator from "../src/validator";
 
 it("will render and submit with a checkbox attribute", async () => {

--- a/tests/form-error-init.spec.tsx
+++ b/tests/form-error-init.spec.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
+import React from "react";
 
 import Form from "../src/form";
 import Input from "./input-component";

--- a/tests/form-status.spec.tsx
+++ b/tests/form-status.spec.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
 
 import Form from "../src/form";
-import Input from "./input-component";
 import { useFormContext } from "../src/form-context";
+import Input from "./input-component";
 
 afterEach(cleanup);
 

--- a/tests/input-component.tsx
+++ b/tests/input-component.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import InputGroup from "../src/input-group";
 
 export const Input = ({ attribute, type }: { attribute: string; type?: string }) => (

--- a/tests/input-group.spec.tsx
+++ b/tests/input-group.spec.tsx
@@ -1,8 +1,9 @@
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import React from "react";
-import { render, fireEvent, waitFor, act } from "@testing-library/react";
+
 import Form from "../src/form";
-import Input from "./input-component";
 import createValidator from "../src/validator";
+import Input from "./input-component";
 
 interface FormModel {
   input: string;

--- a/tests/list-group.spec.tsx
+++ b/tests/list-group.spec.tsx
@@ -1,9 +1,10 @@
-import React from "react";
 import { act, render, renderHook } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
+
 import Form from "../src/form";
-import { ListGroup, ListOption, useListAttribute } from "../src/list-group";
 import { InputGroup } from "../src/input-group";
+import { ListGroup, ListOption, useListAttribute } from "../src/list-group";
 
 it("will render and submit with a radio list", async () => {
   const onSubmit = jest.fn();

--- a/tests/on-change.spec.tsx
+++ b/tests/on-change.spec.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { render, screen, cleanup, act } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
 
 import Form from "../src/form";
 import Input from "./input-component";

--- a/tests/on-submit.spec.tsx
+++ b/tests/on-submit.spec.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import { render, screen, cleanup, act } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
 
 import Form, { OnSubmitFunction } from "../src/form";
-import Input from "./input-component";
 import { useFormContext } from "../src/form-context";
+import Input from "./input-component";
 
 afterEach(cleanup);
 

--- a/tests/radio-group.spec.tsx
+++ b/tests/radio-group.spec.tsx
@@ -1,6 +1,7 @@
-import React from "react";
 import { act, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
+
 import Form from "../src/form";
 import { RadioGroup, RadioOption } from "../src/radio-group";
 

--- a/tests/select-group.spec.tsx
+++ b/tests/select-group.spec.tsx
@@ -1,6 +1,7 @@
-import React, { FC } from "react";
-import { render, fireEvent, waitFor, act } from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React, { FC } from "react";
+
 import Form from "../src/form";
 import SelectGroup from "../src/select-group";
 

--- a/tests/use-attribute.spec.tsx
+++ b/tests/use-attribute.spec.tsx
@@ -1,5 +1,5 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
 import React from "react";
-import { renderHook, act, cleanup } from "@testing-library/react";
 
 import { Form } from "../src/form";
 import { useAttribute, useBooleanAttribute, useStringAttribute } from "../src/use-attribute";

--- a/tests/validation.spec.tsx
+++ b/tests/validation.spec.tsx
@@ -1,11 +1,10 @@
-import React from "react";
-import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
 
 import Form from "../src/form";
-import Input from "./input-component";
-
 import createValidator, { ValidationFunction } from "../src/validator";
+import Input from "./input-component";
 
 afterEach(cleanup);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,6 +2188,11 @@ eslint-plugin-react@^7.31.7, eslint-plugin-react@^7.32.1:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
 
+eslint-plugin-simple-import-sort@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz#cc4ceaa81ba73252427062705b64321946f61351"
+  integrity sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
## Summary

Adds this plugin to automate the sorting of imports and exports. Keeps things tidy and helps in git diffs to see what has been changed.

This is an external package and IMO better because it supports `--fix` so the developer does not have to think about the order and is less prone to error.

## Type of change

<!-- Please remove any points that are not relevant for your pull request -->

- [x] Developer chore (A change to CI or something that does not affect the package features)

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Please complete the checklist as best you can -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)