### PR TITLE
feat: export the dot notation functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./attribute-context";
 export * from "./check-group";
+export * from "./dot-notation";
 export * from "./form";
 export * from "./form-context";
 export * from "./input-group";

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -21,6 +21,11 @@ test.each([
   "useSelectAttribute",
   "useStringAttribute",
   "useTextAttribute",
+
+  // Dot Notation
+  "getAll",
+  "get",
+  "set",
 ])("'%s' is exported from the index file", (variable: string) => {
   expect(ReactForm[variable as keyof typeof ReactForm]).not.toBeUndefined();
 });


### PR DESCRIPTION
## Summary

Export the dot notation function so we can use them in validation rules. This
comes in handy when you want to get all the other attributes when using the
deep scan syntax.

```js
function (formState, { attribute }) {
  const all = getAll(formState, attribute)
}
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

I have made the change locally and tested importing it. I have also added the
functions to the index export test.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)
