### PR TITLE
ci: only do size-limit on PRs

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,7 +1,6 @@
 name: Size Limit
 
 on:
-  push: { branches: ["0.x"] }
   pull_request: { branches: ["0.x"] }
 
 jobs:


### PR DESCRIPTION
## Summary

This is failing when pussing to 0.x there is no PR

## Type of change

- [x] Developer chore (A change to CI or something that does not affect the package features)

## How has this been tested?

This is the test

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)
