### PR TITLE
fix: remove nested errors when removing an item from a list

### DIFF
--- a/src/list-group.tsx
+++ b/src/list-group.tsx
@@ -35,11 +35,14 @@ const defaultNewItem = () => ({});
 const useArrayAttribute = createUseAttributeHook((value) => value);
 
 function removeErrors(setErrors: (errors: ErrorBag) => void, errors: ErrorBag, attribute: string) {
-  if (typeof errors[attribute] !== "undefined") {
-    const newErrors = { ...errors };
-    delete newErrors[attribute];
-    setErrors(newErrors);
+  const newErrors = { ...errors };
+  for (const key of Object.keys(newErrors)) {
+    if (key.startsWith(attribute)) {
+      delete newErrors[key];
+    }
   }
+
+  setErrors(newErrors);
 }
 
 /**


### PR DESCRIPTION
## Summary

Nested errors were not getting removed for example:

Given the data object: `{ myList: [{ name: "Testing" }, { name: "" }] }`
And the errors object: `{ "myList.1.name": ["Item name cannot be blank"] }`

When you remove the second item from the list the errors were not getting removed. This was making it impossible to submit the form.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Unit tests

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)
