### PR TITLE
chore: remove restriction on node 16 so we can update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,6 @@
   "lockFileMaintenance": { "enabled": true },
   "packageRules": [
     {
-      "matchPackageNames": ["node"],
-      "allowedVersions": "<=16"
-    },
-    {
       "matchPackageNames": ["ts-jest", "@types/jest"],
       "matchPackagePatterns": ["^jest", "^@testing-library/"],
       "groupName": "testing packages"


### PR DESCRIPTION
## Summary

We are currently preventing node from getting updated by renovate. We really should be getting up to v20 as v16 is not supported any more.

## Type of change

- [x] Developer chore (A change to CI or something that does not affect the package features)

## How has this been tested?

The CI is the test

## Checklist:

<!-- Please complete the checklist as best you can -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/AdeAttwood/ReactForm/blob/0.x/CONTRIBUTING.md#committing-convention)
